### PR TITLE
Support timeout for WaitForTaskFinsihed

### DIFF
--- a/src/cm_event.cpp
+++ b/src/cm_event.cpp
@@ -444,9 +444,13 @@ CM_RT_API INT CmEvent::WaitForTaskFinished(DWORD dwTimeOutMs)
 
 	while (m_Status != CM_STATUS_FINISHED) {
 		if (m_OsData) {
-			drm_intel_bo_wait_rendering((drm_intel_bo *) m_OsData);
-			drm_intel_gem_bo_clear_relocs((drm_intel_bo *) m_OsData,
-						      0);
+			result = drm_intel_gem_bo_wait((drm_intel_bo*)m_OsData, 1000000LL*dwTimeOutMs);
+			drm_intel_gem_bo_clear_relocs((drm_intel_bo*)m_OsData, 0);
+			if (result) {
+				//translate the drm ecode (-ETIME).
+				result = CM_EXCEED_MAX_TIMEOUT;
+				break;
+			}
 		}
 
 		Query();


### PR DESCRIPTION
Support timeout in WaitForTaskFinished

Call drm_intel_gem_bo_wait(bo, timeout_ns) in CmEvent::WaitForTaskFinished to support timeout.

Signed-off-by: Wei Lin wei.w.lin@intel.com
