### PR TITLE
build: fix library name and SONAME.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,8 +33,6 @@ m4_define([cmrt_api_micro_version], [0])
 m4_define([cmrt_api_version],
           [cmrt_api_major_version.cmrt_api_minor_version.cmrt_api_micro_version])
 
-
-
 # CMRT package version number, (as distinct from shared library version)
 # XXX: we want the package version to remain at 1.0.x for CMRT-API 0.10.y
 #
@@ -54,16 +52,16 @@ m4_append([cmrt_version], cmrt_pre_version, [.pre])
 ])
 
 # CMRT library version number (generated, do not change)
-# XXX: we want the SONAME to remain at libva.so.1 for CMRT-API major == 0
+# XXX: we want the SONAME to remain at libcmrt.so.1 for CMRT-API major == 0
 #
-# The library name is generated libva.<x>.<y>.0 where
+# The library name is generated libcmrt.<x>.<y>.0 where
 # <x> = CMRT-API major version + 1
 # <y> = 100 * CMRT-API minor version + CMRT-API micro version
 #
 # For example:
-# CMRT-API 0.10.0 generates libva.so.1.1000.0
-# CMRT-API 0.14.1 generates libva.so.1.1401.0
-# CMRT-API 1.2.13 generates libva.so.2.213.0
+# CMRT-API 0.10.0 generates libcmrt.so.1.1000.0
+# CMRT-API 0.14.1 generates libcmrt.so.1.1401.0
+# CMRT-API 1.2.13 generates libcmrt.so.2.213.0
 m4_define([cmrt_interface_bias], [m4_eval(cmrt_api_major_version + 1)])
 m4_define([cmrt_interface_age],  [0])
 m4_define([cmrt_binary_age],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,10 +49,9 @@ cmrt_cflags = \
 	$(NULL)
 
 cmrt_ldflags = \
-	-module -avoid-version	\
 	-no-undefined		\
 	-Wl,--no-undefined	\
-	-fPIC \
+	$(CMRT_LT_LDFLAGS)	\
 	$(NULL)
 
 cmrt_libs = \
@@ -106,16 +105,16 @@ cmrt_headers = \
 
 cmrt_config = cmrt.conf
 
-cmrt_la_LTLIBRARIES     = cmrt.la
-cmrt_ladir              = $(libdir)
-cmrtincludedir          = $(includedir)
+libcmrt_la_LTLIBRARIES	= libcmrt.la
+libcmrt_ladir		= $(libdir)
+cmrtincludedir		= $(includedir)
 cmrtconfdir		= $(sysconfdir)
-cmrt_la_CFLAGS          = $(cmrt_cflags)
-cmrt_la_CXXFLAGS        = -fpermissive $(cmrt_cflags)
-cmrt_la_LDFLAGS         = $(cmrt_ldflags)
-cmrt_la_LIBADD          = $(cmrt_libs)
-cmrt_la_SOURCES         = $(cmrt_files)
-cmrtinclude_HEADERS     = $(cmrt_headers)
+libcmrt_la_CFLAGS	= $(cmrt_cflags)
+libcmrt_la_CXXFLAGS	= -fpermissive $(cmrt_cflags)
+libcmrt_la_LDFLAGS	= $(cmrt_ldflags)
+libcmrt_la_LIBADD	= $(cmrt_libs)
+libcmrt_la_SOURCES	= $(cmrt_files)
+cmrtinclude_HEADERS	= $(cmrt_headers)
 cmrtconf_DATA		= $(cmrt_config)
 
 # Extra clean files so that maintainer-clean removes *everything*


### PR DESCRIPTION
CM runtime library is not a module of anything, so fix the name and
the related SONAME to something more meaningful.

Note:
The SONAME is left to libcmrt.so.1 based on the existing ruling from
configure.ac notes. Likewise, library version suffix is made up from
API minor and micro versions.

Signed-off-by: Gwenole Beauchesne gwenole.beauchesne@intel.com
