### PR TITLE
Add more autoconf-related files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,13 @@ libtool
 *.gcno
 *.gcda
 cproject.log
+
+compile
+config.guess
+config.sub
+depcomp
+install-sh
+ltmain.sh
+missing
+src/config.h.in
+


### PR DESCRIPTION
This way one can have a clean "git status" after runing autogen/autoreconf.
