### PR TITLE
Require drm_intel_bo_alloc_userptr() at compile/link time

### DIFF
--- a/src/cm_common.h
+++ b/src/cm_common.h
@@ -38,14 +38,6 @@
 #define EXTERN_C
 #endif
 
-#define DRMVMAP_FUNCTION_STR        "drm_intel_bo_alloc_userptr"
-typedef drm_intel_bo *(*pDrmVMapFnc) (drm_intel_bufmgr * bufmgr,
-				      const char *name,
-				      void *addr,
-				      uint32_t tiling_mode,
-				      uint32_t stride,
-				      unsigned long size, unsigned long flags);
-
 typedef void *DXVAUMD_RESOURCE;
 
 typedef struct cm_tagLOOKUP_ENTRY {

--- a/src/hal_cm.c
+++ b/src/hal_cm.c
@@ -5950,10 +5950,6 @@ VOID HalCm_Destroy(PCM_HAL_STATE pState)
 		}
 		HalCm_FreeTsResource(pState);
 
-		if (pState->hLibModule) {
-			FreeLibrary(pState->hLibModule);
-			pState->hLibModule = NULL;
-		}
 		if (pState->pHwInterface) {
 			pState->pHwInterface->pfnDestroy(pState->pHwInterface);
 			GENOS_FreeMemory(pState->pHwInterface);
@@ -6763,18 +6759,14 @@ GENOS_STATUS HalCm_AllocateBuffer(PCM_HAL_STATE pState,
 			    (pOsInterface->pfnAllocateResource
 			     (pOsInterface, &AllocParams, &pEntry->OsResource));
 		} else {
-			if (pState->hLibModule && pState->pDrmVMap) {
-				bo = pState->pDrmVMap(pOsInterface->
-						      pOsContext->bufmgr,
-						      "CM Buffer UP",
-						      (void *)(pParam->pData),
-						      tileformat,
-						      ROUND_UP_TO(iSize,
-								  GENOS_PAGE_SIZE),
-						      ROUND_UP_TO(iSize,
-								  GENOS_PAGE_SIZE),
-						      0);
-			}
+			bo = (drm_intel_bo *)pOsInterface->pfnAllocUserptr(
+						pOsInterface->pOsContext,
+						"CM Buffer UP",
+						(void *)(pParam->pData),
+						tileformat,
+						ROUND_UP_TO(iSize, GENOS_PAGE_SIZE),
+						ROUND_UP_TO(iSize, GENOS_PAGE_SIZE),
+						0);
 
 			pOsResource->bMapped = FALSE;
 			if (bo) {
@@ -6867,12 +6859,12 @@ GENOS_STATUS HalCm_AllocateSurface2DUP(PCM_HAL_STATE pState,
 	IntelGen_OsResetResource(pOsResource);
 	HalCm_GetSurfPitchSize(iWidth, iHeight, Format, &align_x, &iSize);
 
-	if (pState->hLibModule && pState->pDrmVMap) {
-		bo = pState->pDrmVMap(pOsInterface->pOsContext->bufmgr,
-				      "CM Surface2D UP",
-				      (void *)(pSysMem),
-				      tileformat, align_x, iSize, 0);
-	}
+	bo = (drm_intel_bo *)pOsInterface->pfnAllocUserptr(
+						pOsInterface->pOsContext,
+						"CM Surface2D UP",
+						(void *)(pSysMem),
+						tileformat, align_x,
+						iSize, 0);
 
 	pOsResource->bMapped = FALSE;
 	if (bo) {
@@ -6935,22 +6927,6 @@ GENOS_STATUS HalCm_GetGpuTime(PCM_HAL_STATE pState, PUINT64 pGpuTime)
 	return hr;
 }
 
-VOID HalCm_GetLibDrmVMapFnt(PCM_HAL_STATE pCmState)
-{
-	if (!pCmState->hLibModule) {
-		pCmState->hLibModule = LoadLibrary("libdrm_intel.so");
-	}
-
-	if (pCmState->hLibModule) {
-		pCmState->pDrmVMap =
-		    (pDrmVMapFnc) GetProcAddress(pCmState->hLibModule,
-						 DRMVMAP_FUNCTION_STR);
-	} else {
-		pCmState->pDrmVMap = NULL;
-	}
-	return;
-}
-
 VOID HalCm_OsInitInterface(PCM_HAL_STATE pCmState)
 {
 	CM_ASSERT(pCmState);
@@ -6963,6 +6939,5 @@ VOID HalCm_OsInitInterface(PCM_HAL_STATE pCmState)
 	pCmState->pfnGetGpuTime = HalCm_GetGpuTime;
 	pCmState->pfnConvertToQPCTime = HalCm_ConvertToQPCTime;
 
-	HalCm_GetLibDrmVMapFnt(pCmState);
 	return;
 }

--- a/src/hal_cm.h
+++ b/src/hal_cm.h
@@ -290,10 +290,7 @@ typedef struct _CM_HAL_STATE {
 	CM_HAL_L3_CONFIG L3Config;
 
 	BOOL bNullHwRenderCm;
-	HMODULE hLibModule;
 	DWORD cmDeubgBTIndex;
-
-	pDrmVMapFnc pDrmVMap;
 
 	CM_HAL_POWER_OPTION_PARAM PowerOption;
 	BOOL bEUSaturationEnabled;

--- a/src/os_interface.c
+++ b/src/os_interface.c
@@ -1454,6 +1454,19 @@ HRESULT IntelGen_OsResetCommandBuffer(PGENOS_INTERFACE pOsInterface,
 	return S_OK;
 }
 
+static void* IntelGen_OsAllocUserptr(PGENOS_CONTEXT pOsContext,
+				     const char *name,
+				     void *addr,
+				     uint32_t tilingMode,
+				     uint32_t stride,
+				     unsigned long size,
+				     unsigned long flags)
+{
+	return drm_intel_bo_alloc_userptr(pOsContext->bufmgr,
+					  name, addr, tilingMode,
+					  stride, size, flags);
+}
+
 HRESULT IntelGen_OsInitInterface(PGENOS_INTERFACE pOsInterface,
 				 PGENOS_CONTEXT pOsDriverContext)
 {
@@ -1524,6 +1537,7 @@ HRESULT IntelGen_OsInitInterface(PGENOS_INTERFACE pOsInterface,
 	pOsInterface->pfnGetIndirectStatePointer =
 	    IntelGen_OsGetIndirectStatePointer;
 	pOsInterface->pfnSetPatchEntry = IntelGen_OsSetPatchEntry;
+	pOsInterface->pfnAllocUserptr = IntelGen_OsAllocUserptr;
 
 	pOsInterface->pfnSleepMs = IntelGen_OsSleepMs;
 

--- a/src/os_interface.h
+++ b/src/os_interface.h
@@ -678,6 +678,14 @@ typedef struct _GENOS_INTERFACE {
 	 HRESULT(*pfnResetCommandBuffer) (PGENOS_INTERFACE pOsInterface,
 					  PGENOS_COMMAND_BUFFER pCmdBuffer);
 
+	 PVOID (*pfnAllocUserptr) (PGENOS_CONTEXT pOsContext,
+				   const char *name,
+				   void *addr,
+				   uint32_t tilingMode,
+				   uint32_t stride,
+				   unsigned long size,
+				   unsigned long flags);
+
 } GENOS_INTERFACE;
 
 #ifdef __cplusplus


### PR DESCRIPTION
Using dlopen()/dlsym() for calling this function will result in less
sensbile runtime errors. So require it at compile/link time to make a
clear statement about the libdrm version requirements.
