### PR TITLE
Add empty implementations for abstract functions

### DIFF
--- a/src/cm_device_base.h
+++ b/src/cm_device_base.h
@@ -36,54 +36,54 @@ typedef struct _CM_DLL_FILE_VERSION_ CM_DLL_FILE_VERSION;
 class CmDevice {
  public:
 
-	virtual INT CreateBuffer(UINT size, CmBuffer * &pSurface) = 0;
+	virtual INT CreateBuffer(UINT size, CmBuffer * &pSurface) { return 0; };
 	virtual INT CreateSurface2D(UINT width, UINT height, CM_SURFACE_FORMAT format,
-			    CmSurface2D * &pSurface) = 0;
+			    CmSurface2D * &pSurface) { return 0; };
 
 	virtual INT CreateSurface2D(CmOsResource * pOsResource,
-			    CmSurface2D * &pSurface) = 0;
-	virtual INT CreateBuffer(CmOsResource * pOsResource, CmBuffer * &pSurface) = 0;
+			    CmSurface2D * &pSurface) { return 0; };
+	virtual INT CreateBuffer(CmOsResource * pOsResource, CmBuffer * &pSurface) { return 0; };
 
-	virtual INT CreateBufferUP(UINT size, void *pSystMem, CmBufferUP * &pSurface) = 0;
-	virtual INT DestroyBufferUP(CmBufferUP * &pSurface) = 0;
+	virtual INT CreateBufferUP(UINT size, void *pSystMem, CmBufferUP * &pSurface) { return 0; };
+	virtual INT DestroyBufferUP(CmBufferUP * &pSurface) { return 0; };
 
 	virtual INT CreateSurface2DUP(UINT width, UINT height,
 			      CM_SURFACE_FORMAT format, void *pSysMem,
-			      CmSurface2DUP * &pSurface) = 0;
-	virtual INT DestroySurface(CmSurface2DUP * &pSurface) = 0;
+			      CmSurface2DUP * &pSurface) { return 0; };
+	virtual INT DestroySurface(CmSurface2DUP * &pSurface) { return 0; };
 
-	virtual INT DestroySurface(CmBuffer * &pSurface) = 0;
-	virtual INT DestroySurface(CmSurface2D * &pSurface) = 0;
+	virtual INT DestroySurface(CmBuffer * &pSurface) { return 0; };
+	virtual INT DestroySurface(CmSurface2D * &pSurface) { return 0; };
 
 	virtual INT GetSurface2DInfo(UINT width, UINT height, CM_SURFACE_FORMAT format,
-			     UINT & pitch, UINT & physicalSize) = 0;
+			     UINT & pitch, UINT & physicalSize) { return 0; };
 
-	virtual INT CreateQueue(CmQueue * &pQueue) = 0;
+	virtual INT CreateQueue(CmQueue * &pQueue) { return 0; };
 	virtual INT LoadProgram(void *pCommonISACode, const UINT size,
-			CmProgram * &pProgram, const char *options = NULL) = 0;
+			CmProgram * &pProgram, const char *options = NULL) { return 0; };
 	virtual INT CreateKernel(CmProgram * pProgram, const char *kernelName,
-			 CmKernel * &pKernel, const char *options = NULL) = 0;
-	virtual INT DestroyKernel(CmKernel * &pKernel) = 0;
-	virtual INT DestroyProgram(CmProgram * &pProgram) = 0;
+			 CmKernel * &pKernel, const char *options = NULL) { return 0; };
+	virtual INT DestroyKernel(CmKernel * &pKernel) { return 0; };
+	virtual INT DestroyProgram(CmProgram * &pProgram) { return 0; };
 
-	virtual INT CreateTask(CmTask * &pTask) = 0;
-	virtual INT DestroyTask(CmTask * &pTask) = 0;
+	virtual INT CreateTask(CmTask * &pTask) { return 0; };
+	virtual INT DestroyTask(CmTask * &pTask) { return 0; };
 
 	virtual INT CreateThreadGroupSpace(UINT thrdSpaceWidth, UINT thrdSpaceHeight,
 				   UINT grpSpaceWidth, UINT grpSpaceHeight,
-				   CmThreadGroupSpace * &pTGS) = 0;
-	virtual INT DestroyThreadGroupSpace(CmThreadGroupSpace * &pTGS) = 0;
+				   CmThreadGroupSpace * &pTGS) { return 0; };
+	virtual INT DestroyThreadGroupSpace(CmThreadGroupSpace * &pTGS) { return 0; };
 
-	virtual INT CreateThreadSpace(UINT width, UINT height, CmThreadSpace * &pTS) = 0;
-	virtual INT DestroyThreadSpace(CmThreadSpace * &pTS) = 0;
+	virtual INT CreateThreadSpace(UINT width, UINT height, CmThreadSpace * &pTS) { return 0; };
+	virtual INT DestroyThreadSpace(CmThreadSpace * &pTS) { return 0; };
 
-	virtual INT SetSuggestedL3Config( L3_SUGGEST_CONFIG l3_s_c) = 0;
+	virtual INT SetSuggestedL3Config( L3_SUGGEST_CONFIG l3_s_c) { return 0; };
 /*
-	virtual INT GetRTDllVersion(CM_DLL_FILE_VERSION * pFileVersion) = 0;
+	virtual INT GetRTDllVersion(CM_DLL_FILE_VERSION * pFileVersion) { return 0; };
 */
 	virtual INT GetRTDllVersion(CM_DLL_FILE_VERSION * pFileVersion) {return 0;};
 	virtual INT GetCaps(CM_DEVICE_CAP_NAME capName, size_t & capValueSize,
-		    void *pCapValue) = 0;
+		    void *pCapValue) { return 0; };
         virtual ~CmDevice(){};
 };
 


### PR DESCRIPTION
The issue is that traditional cmrt applications (not using dynamic loading, but link at build time) failed to build with cmrt library due to link error such as:
/work/cmrt/otc_version/tests_from_itflex/Examples/sharpen/sharpen/sharpen.cpp:146: undefined reference to `CmDevice::CreateSurface2D(un
signed int, unsigned int, _VA_CM_FORMAT, CmSurface2D*&)'
/work/cmrt/otc_version/tests_from_itflex/Examples/sharpen/sharpen/sharpen.cpp:153: undefined reference to`CmSurface2D::WriteSurface(un
signed char const_, CmEvent_, unsigned long)'
/work/cmrt/otc_version/tests_from_itflex/Examples/sharpen/sharpen/sharpen.cpp:160: undefined reference to `CmDevice::CreateSurface2D(un
signed int, unsigned int, _VA_CM_FORMAT, CmSurface2D*&)'
/work/cmrt/otc_version/tests_from_itflex/Examples/sharpen/sharpen/sharpen.cpp:167: undefined reference to`CmDevice::CreateSurface2D(un
signed int, unsigned int, _VA_CM_FORMAT, CmSurface2D_&)'
/work/cmrt/otc_version/tests_from_itflex/Examples/sharpen/sharpen/sharpen.cpp:205: undefined reference to `CmDevice::LoadProgram(void_,
unsigned int, CmProgram_&, char const_)'
/work/cmrt/otc_version/tests_from_itflex/Examples/sharpen/sharpen/sharpen.cpp:213: undefined reference to `CmDevice::CreateKernel(CmPro
gram*, char const*, CmKernel*&, char const*)'
/work/cmrt/otc_version/tests_from_itflex/Examples/sharpen/sharpen/sharpen.cpp:223: undefined reference to`CmKernel::SetThreadCount(uns
igned int)'
/work/cmrt/otc_version/tests_from_itflex/Examples/sharpen/sharpen/sharpen.cpp:231: undefined reference to `CmSurface2D::GetIndex(Surfac
eIndex*&)'

Signed-off-by: Sean V Kelley seanvk@posteo.de
