### PR TITLE
get device rev id inside CMRT when the input value is -1

### DIFF
--- a/src/os_interface.c
+++ b/src/os_interface.c
@@ -383,7 +383,12 @@ HRESULT Ctx_InitContext(GENOS_OS_CONTEXT * pContext,
 		pContext->platform.pchDeviceID = iDeviceId;
 
 		pContext->wRevision = pOsDriverContext->wRevision;
-		pContext->platform.usRevId = pOsDriverContext->wRevision;
+
+		if (pOsDriverContext->wRevision == -1) {
+			getRevId(&pContext->platform.usRevId);
+		} else {
+			pContext->platform.usRevId = pOsDriverContext->wRevision;
+		}
 	} else {
 		pContext->fd = OpenDevice();
 		if (pContext->fd < 0) {


### PR DESCRIPTION
the method to get rev id does not relative to libdrm functions, since
CMRT itself has already provided the method, so the higher layer does
not need to implement the same method again, just let CMRT do the query.
