### PR TITLE
CM_VERSION change to CM_5_0

### DIFF
--- a/src/cm_common.h
+++ b/src/cm_common.h
@@ -387,7 +387,8 @@ typedef enum _CM_RETURN_CODE {
 #define CM_NUM_DWORD_FOR_MW_PARAM        16
 
 #define CM_DDI_1_0 100
-#define CM_DDI_1_1 101 #define CM_DDI_1_2 102
+#define CM_DDI_1_1 101
+#define CM_DDI_1_2 102
 #define CM_DDI_1_3 103
 #define CM_DDI_1_4 104
 #define CM_DDI_2_0 200
@@ -397,8 +398,9 @@ typedef enum _CM_RETURN_CODE {
 #define CM_DDI_2_4 204
 #define CM_DDI_3_0 300
 #define CM_DDI_4_0 400
+#define CM_DDI_5_0 500
 
-#define DXVA_CM_VERSION       CM_DDI_4_0
+#define DXVA_CM_VERSION       CM_DDI_5_0
 #define VA_CM_VERSION         DXVA_CM_VERSION
 
 typedef struct _CM_HAL_STATE *PCM_HAL_STATE;

--- a/src/cm_def.h
+++ b/src/cm_def.h
@@ -65,7 +65,13 @@ typedef unsigned char byte;
 #define CM_2_4 204
 #define CM_3_0 300
 #define CM_4_0 400
-#define CURRENT_CM_VERSION  CM_4_0
+#define CM_5_0 500
+#define CURRENT_CM_VERSION  CM_5_0
+
+#define MANVERSION      5
+#define MANREVISION     0
+#define SUBREVISION     0
+#define BUILD_NUMBER    1001
 
 #define CM_RT_API
 
@@ -286,6 +292,14 @@ typedef enum _CM_STATUS {
 	CM_STATUS_FINISHED = 2,
 	CM_STATUS_STARTED = 3
 } CM_STATUS;
+
+typedef struct _CM_DLL_FILE_VERSION
+{
+    WORD wMANVERSION;
+    WORD wMANREVISION;
+    WORD wSUBREVISION;
+    WORD wBUILD_NUMBER;
+} CM_DLL_FILE_VERSION, *PCM_DLL_FILE_VERSION;
 
 typedef enum _CM_TS_FLAG {
 	WHITE = 0,

--- a/src/cm_device.cpp
+++ b/src/cm_device.cpp
@@ -45,6 +45,10 @@
 #include "readconf.h"
 
 CSync CmDevice_RT::GlobalCriticalSection_Surf2DUserDataLock = CSync();
+CM_DLL_FILE_VERSION CmDevice_RT::m_RTDllVersion = {(WORD)MANVERSION,
+                                                   (WORD)MANREVISION,
+                                                   (WORD)SUBREVISION,
+                                                   (WORD)BUILD_NUMBER};
 
 INT CmDevice_RT::Create(CmDriverContext * pDriverContext, CmDevice_RT * &pDevice,
 		     UINT DevCreateOption)
@@ -581,6 +585,22 @@ CM_RT_API INT CmDevice_RT::DestroySurface(CmSurface2D * &pSurface)
 	}
 
 	return status;
+}
+
+CM_RT_API INT CmDevice_RT::GetRTDllVersion(CM_DLL_FILE_VERSION* pFileVersion)
+{
+    if (pFileVersion)
+    {
+        pFileVersion->wMANVERSION   = m_RTDllVersion.wMANVERSION;
+        pFileVersion->wMANREVISION  = m_RTDllVersion.wMANREVISION;
+        pFileVersion->wSUBREVISION  = m_RTDllVersion.wSUBREVISION;
+        pFileVersion->wBUILD_NUMBER = m_RTDllVersion.wBUILD_NUMBER;
+        return CM_SUCCESS;
+    }
+    else
+    {
+        return CM_QUERY_DLL_VERSION_FAILURE;
+    }
 }
 
 INT CmDevice_RT::GetJITCompileFnt(pJITCompile & fJITCompile)

--- a/src/cm_device.h
+++ b/src/cm_device.h
@@ -108,6 +108,7 @@ class CmDevice_RT : public CmDevice {
 	CM_RT_API INT DestroyThreadGroupSpace(CmThreadGroupSpace * &pTGS);
 
         CM_RT_API INT SetSuggestedL3Config( L3_SUGGEST_CONFIG l3_s_c);
+	CM_RT_API INT GetRTDllVersion(CM_DLL_FILE_VERSION* pFileVersion);
 
 	void *GetAccelData(void) {
 		return m_pAccelData;
@@ -223,6 +224,7 @@ class CmDevice_RT : public CmDevice {
 	pFreeBlock m_fFreeBlock;
 	pJITVersion m_fJITVersion;
 
+	static CM_DLL_FILE_VERSION m_RTDllVersion;
 	UINT m_DDIVersion;
 	UINT m_Platform;
 	UINT m_CmDeviceRefCount;

--- a/src/cm_device_base.h
+++ b/src/cm_device_base.h
@@ -31,8 +31,6 @@
 #ifndef _Cm_Device_Base_H_
 #define _Cm_Device_Base_H_
 
-typedef struct _CM_DLL_FILE_VERSION_ CM_DLL_FILE_VERSION;
-
 class CmDevice {
  public:
 
@@ -78,10 +76,7 @@ class CmDevice {
 	virtual INT DestroyThreadSpace(CmThreadSpace * &pTS) = 0;
 
 	virtual INT SetSuggestedL3Config( L3_SUGGEST_CONFIG l3_s_c) = 0;
-/*
 	virtual INT GetRTDllVersion(CM_DLL_FILE_VERSION * pFileVersion) = 0;
-*/
-	virtual INT GetRTDllVersion(CM_DLL_FILE_VERSION * pFileVersion) {return 0;};
 	virtual INT GetCaps(CM_DEVICE_CAP_NAME capName, size_t & capValueSize,
 		    void *pCapValue) = 0;
         virtual ~CmDevice(){};

--- a/src/cm_rt.h
+++ b/src/cm_rt.h
@@ -66,9 +66,12 @@
 #ifndef CM_4_0
 #define CM_4_0          400
 #endif
+#ifndef CM_5_0
+#define CM_5_0          500
+#endif
 
 #ifndef __INTEL_MDF
-#define __INTEL_MDF     CM_4_0
+#define __INTEL_MDF     CM_5_0
 #endif
 
 #define CM_SUCCESS                                  0

--- a/src/os_interface.c
+++ b/src/os_interface.c
@@ -1871,6 +1871,7 @@ static int updatePlatformInfo(PLATFORM * pPlatform)
 		pPlatform->GtType = GTTYPE_GT2;
 		break;
 	case ISKL_GT3_DESK_DEVICE_F0_ID:
+	case ISKL_GT3_ULT_DEVICE_F0_ID:
 		platform_setTypeAndFamily(pPlatform, PLATFORM_DESKTOP,
 					  IGFX_SKYLAKE, IGFX_GEN9_CORE,
 					  IGFX_GEN9_CORE);


### PR DESCRIPTION
CM_VERSION change from CM_4_0 to CM_5_0 in order to mark SKL support.
Add API GetRTDllVersion to query current CM version.

Signed-off-by: Wei Lin wei.w.lin@intel.com
