### PR TITLE
Update os_interface.c

### DIFF
--- a/src/os_interface.c
+++ b/src/os_interface.c
@@ -1865,6 +1865,7 @@ static int updatePlatformInfo(PLATFORM * pPlatform)
 		break;
 	case ISKL_GT2_DESK_DEVICE_F0_ID:
 	case ISKL_GT2_DT_DEVICE_F0_ID:
+	case ISKL_GT2_WRK_DEVICE_F0_ID:
 		platform_setTypeAndFamily(pPlatform, PLATFORM_DESKTOP,
 					  IGFX_SKYLAKE, IGFX_GEN9_CORE,
 					  IGFX_GEN9_CORE);


### PR DESCRIPTION
Add case for ISKL_GT2_WRK_DEVICE_F0_ID
This is a fix for issue #41
